### PR TITLE
Continue on error

### DIFF
--- a/dedupe/audit.py
+++ b/dedupe/audit.py
@@ -18,5 +18,5 @@ class RemovedPackageLog(object):
 
 
     def add(self, package):
-        log.debug('Saving package to removed package log packge=%s', package['id'])
+        log.debug('Saving package to removed package log package=%s', package['id'])
         self.log.write(json.dumps(package) + '\n')

--- a/dedupe/ckan_api.py
+++ b/dedupe/ckan_api.py
@@ -131,7 +131,7 @@ class CkanApiClient(object):
             log.info('Not removing package in dry_run package=%s', package_id)
             return
 
-        self.request('POST', '/action/package_delete', params={
+        self.request('POST', '/action/package_delete', json={
             'id': package_id,
         })
 

--- a/dedupe/ckan_api.py
+++ b/dedupe/ckan_api.py
@@ -14,7 +14,27 @@ class CkanApiException(Exception):
         self.response = response
 
 
+class CkanApiFailureException(CkanApiException):
+    '''
+    CKAN API reported success: false. It should be okay to continue using the API.
+    '''
+    pass
+
+
+class CkanApiStatusException(CkanApiException):
+    '''
+    CKAN API returned an unhealthy status code. This indicates something might
+    not be working correctly with our configuration or the server could be
+    having issues and we should not continue using the API in this state.
+    '''
+    pass
+
+
 class DryRunException(Exception):
+    '''
+    Something happened during a dry-run execution that shouldn't have, like
+    trying to write to the API.
+    '''
     pass
 
 
@@ -39,9 +59,11 @@ class CkanApiClient(object):
         kwargs.setdefault('timeout', 60)
 
         response = self.client.request(method, url, **kwargs)
+        if response.status_code >= 400:
+            raise CkanApiStatusException('Unsuccessful status code %d' % response.status_code, response)
 
-        assert response.status_code == 200
-        assert response.json()['success']
+        if not response.json().get('success', False):
+            raise CkanApiFailureException('API reported failure', response)
 
         return response
 

--- a/dedupe/ckan_api.py
+++ b/dedupe/ckan_api.py
@@ -60,9 +60,11 @@ class CkanApiClient(object):
 
         response = self.client.request(method, url, **kwargs)
         if response.status_code >= 400:
+            log.error('Unsuccessful status code status=%d body=%s', response.status_code, response.content)
             raise CkanApiStatusException('Unsuccessful status code %d' % response.status_code, response)
 
         if not response.json().get('success', False):
+            log.error('API failure status=%d body=%s', response.status_code, response.content)
             raise CkanApiFailureException('API reported failure', response)
 
         return response

--- a/dedupe/deduper.py
+++ b/dedupe/deduper.py
@@ -5,6 +5,8 @@ most recent duplicate and removes the rest.
 
 import logging
 
+from .ckan_api import CkanApiException
+
 module_log = logging.getLogger(__name__)
 
 
@@ -29,14 +31,25 @@ class Deduper(object):
 
         duplicate_count = 0
         for identifier in harvester_identifiers:
-            duplicate_count += self.dedupe_harvest_identifier(identifier['name'])
+            try:
+                duplicate_count += self.dedupe_harvest_identifier(identifier['name'])
+            except CkanApiException, e:
+                self.log.error('Failed to dedupe harvest identifier=%s', identifier['name'])
+                continue
 
         self.log.info('Summary duplicate_count=%d', duplicate_count)
 
     def replace_oldest_dataset_with_newest(self, harvest_identifier):
+        self.log.debug('Fetching oldest and most recent pacakges for harvest identifier=%s', harvest_identifier)
         oldest_dataset = self.ckan_api.get_oldest_dataset(harvest_identifier)
         newest_dataset = self.ckan_api.get_newest_dataset(harvest_identifier)
 
+        self.log.info('Replacing oldest dataset with most recent oldest=%r newest=%r identifier=%s',
+                      (oldest_dataset['id'], oldest_dataset['name']),
+                      (newest_dataset['id'], newest_dataset['name']),
+                      harvest_identifier)
+
+        # save the original dataset name to give it to the most recent
         name = oldest_dataset['name']
 
         # update oldest dataset
@@ -54,7 +67,7 @@ class Deduper(object):
         return newest_dataset
 
     def remove_package(self, package):
-        self.log.info('Removing duplicate package=%s', package['id'])
+        self.log.info('Removing duplicate package=%r', (package['id'], package['name']))
         if self.removed_package_log:
             self.removed_package_log.add(package)
 
@@ -100,15 +113,20 @@ class Deduper(object):
         duplicate_count = 0
         for dataset in get_datasets(harvest_data_count):
             if dataset['organization']['name'] != self.organization_name:
-                log.warning('Dataset harvested by organization but not part of organization pkg_org_name=%s pkg_name=%s',
-                            dataset['organization']['name'], dataset['name'])
+                log.warning('Dataset harvested by organization but not part of organization pkg_org_name=%s package=%r',
+                            dataset['organization']['name'], (dataset['id'], dataset['name']))
                 continue
 
             if dataset['id'] == new_dataset['id']:
                 log.debug('This package is the most recent, not removing package=%s', dataset['id'])
                 continue
 
-            self.remove_package(dataset)
             duplicate_count += 1
+            try:
+                self.remove_package(dataset)
+            except CkanApiException, e:
+                log.error('Failed to remove dataset status_code=%s package=%r', e.response.status_code, (dataset['id'], dataset['name']))
+                continue
+
 
         return duplicate_count

--- a/dedupe/deduper.py
+++ b/dedupe/deduper.py
@@ -59,6 +59,11 @@ class Deduper(object):
         # save the original dataset name to give it to the most recent
         name = oldest_dataset['name']
 
+        if name.endswith('-dedupe-purge'):
+            self.log.warning('Package already renamed, continuing without rename package=%r',
+                             (oldest_dataset['id'], oldest_dataset['name']))
+            return newest_dataset
+
         # update oldest dataset
         self.log.info('Renaming oldest dataset identifier=%s package=%s name=%s',
                       harvest_identifier, oldest_dataset['id'], oldest_dataset['name'])

--- a/duplicates-identifier-api.py
+++ b/duplicates-identifier-api.py
@@ -52,13 +52,8 @@ def run():
 
     # Loop over the organizations one at a time
     for organization in org_list:
-        try:
-            deduper = Deduper(organization, ckan_api, removed_package_log)
-            deduper.dedupe()
-        except Exception as e:
-            log.exception(e)
-            # Continue with the next organization
-            continue
+        deduper = Deduper(organization, ckan_api, removed_package_log)
+        deduper.dedupe()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Continue on errors in cases where the API fails, but die on more significant errors. Improves logging and some fixes from running in test.