### PR TITLE
Retain original package instead of most recent

### DIFF
--- a/dedupe/audit.py
+++ b/dedupe/audit.py
@@ -31,6 +31,7 @@ class RemovedPackageLog(object):
 
 
 class DuplicatePackageLog(object):
+    # Order matters here for the report
     fieldnames = [
         'organization',                   # Organization name
         'duplicate_id',                   # Duplicate id (CKAN ID)
@@ -43,7 +44,6 @@ class DuplicatePackageLog(object):
         'retained_id',          # Retained id (CKAN id)
         'retained_url',         # Retained URL (site URL + CKAN name)
         'retained_metadata_created',      # Retained metadata_created
-        'retained_new_name',              # New name of the retained dataset once the rename is applied
     ]
 
     def __init__(self, filename=None, api_url=None, run_id=None):
@@ -65,18 +65,17 @@ class DuplicatePackageLog(object):
     def add(self, duplicate_package, retained_package):
         log.debug('Recording duplicate package to report package=%s', duplicate_package['id'])
         self.log.writerow({
-            'organization': duplicate_package['organization']['name'],
             'duplicate_id': duplicate_package['id'],
-            'duplicate_title': duplicate_package['title'],
-            'duplicate_name': duplicate_package['name'],
-            'duplicate_url': '%s/dataset/%s' % (self.api_url, duplicate_package['name']),
-            'duplicate_metadata_created': duplicate_package['metadata_created'],
             'duplicate_identifier': util.get_package_extra(duplicate_package, 'identifier'),
+            'duplicate_metadata_created': duplicate_package['metadata_created'],
+            'duplicate_name': duplicate_package['name'],
             'duplicate_source_hash': util.get_package_extra(duplicate_package, 'source_hash'),
+            'duplicate_title': duplicate_package['title'],
+            'duplicate_url': '%s/dataset/%s' % (self.api_url, duplicate_package['name']),
+            'organization': duplicate_package['organization']['name'],
             'retained_id': retained_package['id'],
-            'retained_url': '%s/dataset/%s' % (self.api_url, retained_package['name']),
             'retained_metadata_created': retained_package['metadata_created'],
-            'retained_new_name': util.get_package_extra(retained_package, 'datagov_dedupe')['rename_to'],
+            'retained_url': '%s/dataset/%s' % (self.api_url, retained_package['name']),
         })
 
         # Persist the write to disk

--- a/dedupe/ckan_api.py
+++ b/dedupe/ckan_api.py
@@ -97,6 +97,7 @@ class CkanApiClient(object):
     def get_harvester_identifiers(self, organization_name):
         response = self.get('/3/action/package_search', params={
             'q': 'organization:"%s" AND state:"active"' % organization_name,
+            'fq': 'type:dataset',
             'facet.field': '["identifier"]',
             'facet.limit': -1,
             'facet.mincount': 2,
@@ -119,6 +120,7 @@ class CkanApiClient(object):
     def get_datasets(self, organization_name, harvest_identifier, start=0, rows=1000):
         response = self.get('/action/package_search', params={
             'q': 'identifier:"%s" AND state:"active"' % harvest_identifier,
+            'fq': 'type:dataset',
             'start': start,
             'rows': rows,
             })

--- a/dedupe/ckan_api.py
+++ b/dedupe/ckan_api.py
@@ -96,10 +96,11 @@ class CkanApiClient(object):
 
     def get_harvester_identifiers(self, organization_name):
         response = self.get('/3/action/package_search', params={
-            'q': 'organization:%s' % organization_name,
+            'q': 'organization:"%s" AND state:"active"' % organization_name,
             'facet.field': '["identifier"]',
             'facet.limit': -1,
             'facet.mincount': 2,
+            'rows': 0,
             })
 
         return response.json()['result']['search_facets']['identifier']['items']
@@ -107,7 +108,7 @@ class CkanApiClient(object):
 
     def get_dataset_count(self, organization_name, harvest_identifier):
         response = self.get('/action/package_search', params={
-            'q': 'identifier:"%s"' % harvest_identifier,
+            'q': 'identifier:"%s" AND state:"active"' % harvest_identifier,
             'fq': 'type:dataset',
             'sort': 'metadata_created desc',
             'rows': 0,
@@ -117,7 +118,7 @@ class CkanApiClient(object):
 
     def get_datasets(self, organization_name, harvest_identifier, start=0, rows=1000):
         response = self.get('/action/package_search', params={
-            'q': 'identifier:"%s"' % harvest_identifier,
+            'q': 'identifier:"%s" AND state:"active"' % harvest_identifier,
             'start': start,
             'rows': rows,
             })

--- a/dedupe/deduper.py
+++ b/dedupe/deduper.py
@@ -80,39 +80,12 @@ class Deduper(object):
         Mark the retained package with a datagov_dedupe property in case we're
         interrupted. This allows us to continue with removing duplicates when we resume.
 
-        This also let's us store the original name so that we can rename the
-        retained package at the very end. We need to capture the original
-        datasets name before it is removed.
+        Note: we're currently not mutating the data in a way that wouldn't be idempotent.
         '''
-
-        # Make the package with its to-be new name
-        # We don't rename it yet, because our logs become confusing.
-        # Instead, we rename at the end after the logs have been written
-        # and all the duplicates removed. We have to record the name now
-        # because the oldest package could be removed. If the oldest
-        # package is removed and then we're interrupted, we won't know what
-        # the reall oldest pacakge was.
-        identifier = util.get_package_extra(retained_package, 'identifier')
-
-        self.log.debug('Fetching original dataset for harvest identifier=%s', identifier)
-        original_dataset = self.ckan_api.get_oldest_dataset(identifier)
-
-        # Rename the original package to prevent name conflict
-        original_name = original_dataset['name']
-        if not original_name.endswith('-dedupe-purge'):
-            # Add suffix, maintain the max-length limit
-            original_dataset['name'] = ('%s-dedupe-purge' % original_name)[:PACKAGE_NAME_MAX_LENGTH]
-            self.log.info('Rename original name=%s package=%r',
-                          original_dataset['name'], (original_dataset['id'], original_name))
-            self.ckan_api.update_package(original_dataset)
-        else:
-            self.log.warning('Dataset already renamed, continuing without rename package=%r',
-                             (original_dataset['id'], original_dataset['name']))
-
         self.log.info('Marking retained dataset for idempotency package=%r',
                       (retained_package['id'], retained_package['name']))
         util.set_package_extra(retained_package, 'datagov_dedupe',
-                               dict(rename_to=original_name))
+                               self.run_id)
 
         # Call the update API
         self.log.debug('Mark retained package in API package=%r',
@@ -122,12 +95,8 @@ class Deduper(object):
 
     def commit_retained_package(self, retained_package):
         '''
-        Unmarks the package for deduplication and commits the rename.
+        Unmarks the package for deduplication and commits any data changes.
         '''
-        # Get the new name for the package
-        name = util.get_package_extra(retained_package, 'datagov_dedupe')['rename_to']
-        retained_package['name'] = name
-
         # Mark the retained package
         util.set_package_extra(retained_package, 'datagov_dedupe', None)
         util.set_package_extra(retained_package, 'datagov_dedupe_retained', self.run_id)
@@ -144,21 +113,18 @@ class Deduper(object):
 
         1. Get the number of datasets with this identifier.
            a. If there is only one dataset, no duplicates. Continue with next identifier.
-        2. Fetch the most recent dataset which is to be retained.
-        3. Mark the retained dataset as being processed. This records some
-           additional information before we actually start removing duplicates,
-           like the original dataset name.
+        2. Fetch the oldest dataset which is to be retained.
+        3. Mark the retained dataset as being processed.
         4. Fetch the datasets for this identifier in batches.
         5. For each dataset:
            a. Check if this is the retained dataset, in which we skip.
            b. Remove the dataset.
-        6. Commit the retained dataset as being processed and rename it to the
-           original name.
+        6. Commit the retained dataset as being processed.
 
-        We make sure the rename of the retained dataset happens last. This
+        We make sure the commit of the retained dataset happens last. This
         keeps the logging cleaner, since we don't want to confuse ourselves
-        logging information that is changing. This also means the same
-        information is logged in dry-run vs read/write.
+        logging information that is potentially changing. This also means the
+        same information is logged in dry-run vs read/write.
 
         Returns the number of duplicate datasets.
         '''
@@ -177,9 +143,9 @@ class Deduper(object):
             log.debug('No duplicates found for harvest identifier.')
             return 0
 
-        # We want to keep the most recent dataset
+        # We want to keep the oldest dataset
         self.log.debug('Fetching most recent dataset for harvest identifier=%s', identifier)
-        retained_dataset = self.ckan_api.get_newest_dataset(identifier)
+        retained_dataset = self.ckan_api.get_oldest_dataset(identifier)
 
         # Check if the dedupe process has been started on this package
         if not util.get_package_extra(retained_dataset, 'datagov_dedupe'):

--- a/dedupe/deduper.py
+++ b/dedupe/deduper.py
@@ -1,6 +1,6 @@
 '''
 Duper looks for duplicate packages within a single organization, updates the
-most recent duplicate and removes the rest.
+retained package and removes the rest.
 '''
 
 from datetime import datetime
@@ -144,7 +144,7 @@ class Deduper(object):
             return 0
 
         # We want to keep the oldest dataset
-        self.log.debug('Fetching most recent dataset for harvest identifier=%s', identifier)
+        self.log.debug('Fetching oldest dataset for harvest identifier=%s', identifier)
         retained_dataset = self.ckan_api.get_oldest_dataset(identifier)
 
         # Check if the dedupe process has been started on this package
@@ -191,7 +191,7 @@ class Deduper(object):
                 continue
 
             if dataset['id'] == retained_dataset['id']:
-                log.debug('This package is the most recent, not removing package=%s', dataset['id'])
+                log.debug('This package is the retained dataset, not removing package=%s', dataset['id'])
                 continue
 
             duplicate_count += 1

--- a/dedupe/deduper.py
+++ b/dedupe/deduper.py
@@ -52,7 +52,7 @@ class Deduper(object):
         count = itertools.count(start=1)
         for identifier in harvester_identifiers:
             if self.stopped:
-                break
+                return
 
             self.log.info('Deduplicating identifier=%s progress=%r',
                           identifier['name'], (next(count), len(harvester_identifiers)))
@@ -183,7 +183,7 @@ class Deduper(object):
         for dataset in get_datasets(harvest_data_count):
             if self.stopped:
                 self.log.debug('Deduper is stopped, cleaning up...')
-                break
+                return duplicate_count
 
             if dataset['organization']['name'] != self.organization_name:
                 log.warning('Dataset harvested by organization but not part of organization pkg_org_name=%s package=%r',

--- a/dedupe/deduper.py
+++ b/dedupe/deduper.py
@@ -170,8 +170,11 @@ class Deduper(object):
                     'Batch fetching datasets for harvest offset=%d rows=%d total=%d',
                     start, rows, total)
                 datasets = self.ckan_api.get_datasets(self.organization_name, identifier, start, rows)
-                start += len(datasets)
+                if len(datasets) < 1:
+                    log.warning('Got zero datasets from API offset=%d total=%d', start, total)
+                    raise StopIteration
 
+                start += len(datasets)
                 for dataset in datasets:
                     yield dataset
 


### PR DESCRIPTION
This avoids us having to do the rename. We think keeping the original dataset is
less risky, as there could be relationships to the original package that would
be lost if removed. We're also uncertain about how complete the more recent
datasets are, possibly missing topic tags or other curated data. Instead, we'll
keep the original dataset and then update it with the usual harvest process
(outside of this deduplication process).