### PR TITLE
Keep newest dataset option

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,20 +7,20 @@ Detect and remove duplicate packages on data.gov.
 
 Install the dependencies.
 
-    $ pip install -r requirements.txt
+    $ pipenv sync
 
 Deduplicate packages for a specific organization.
 
-    $ python duplicates-identifier-api.py [organization-name]
+    $ pipenv run python duplicates-identifier-api.py [organization-name]
 
 Scan all organizations and dedupe packges for each.
 
-    $ python duplicates-identifier-api.py
+    $ pipenv run python duplicates-identifier-api.py
 
 View the full help documentation with `--help`.
 
 ```
-$ python duplicates-identifier-api.py --help
+$ pipenv run python duplicates-identifier-api.py --help
 usage: duplicates-identifier-api.py [-h] [--api-key API_KEY]
                                     [--api-url API_URL] [--commit] [--debug]
                                     [--run-id RUN_ID] [--verbose]
@@ -40,6 +40,8 @@ optional arguments:
   --debug            Include debug output from urllib3.
   --run-id RUN_ID    An identifier for a single run of the deduplication
                      script.
+  --newest           Keep the newest dataset and remove older ones 
+                     (by default the oldest is kept)
   --verbose, -v      Include verbose log output.
 ```
 

--- a/dedupe/ckan_api.py
+++ b/dedupe/ckan_api.py
@@ -83,7 +83,7 @@ class CkanApiClient(object):
     def get(self, path, **kwargs):
         return self.request('GET', path, **kwargs)
 
-    def get_oldest_dataset(self, organization_name, identifier, is_collection):
+    def get_dataset_to_save(self, organization_name, identifier, is_collection, oldest=True):
         filter_query = \
             'identifier:"%s" AND organization:"%s" AND type:dataset' % \
             (identifier, organization_name)
@@ -93,7 +93,7 @@ class CkanApiClient(object):
         rows = 1
         response = self.get('/action/package_search', params={
             'fq': filter_query,
-            'sort': 'metadata_created asc',
+            'sort': 'metadata_created asc' if oldest else 'metadata_created desc',
             'rows': rows,
             })
 

--- a/dedupe/ckan_api.py
+++ b/dedupe/ckan_api.py
@@ -83,7 +83,7 @@ class CkanApiClient(object):
     def get(self, path, **kwargs):
         return self.request('GET', path, **kwargs)
 
-    def get_dataset_to_save(self, organization_name, identifier, is_collection, oldest=True):
+    def get_dataset(self, organization_name, identifier, is_collection, sort_order='asc'):
         filter_query = \
             'identifier:"%s" AND organization:"%s" AND type:dataset' % \
             (identifier, organization_name)
@@ -93,7 +93,7 @@ class CkanApiClient(object):
         rows = 1
         response = self.get('/action/package_search', params={
             'fq': filter_query,
-            'sort': 'metadata_created asc' if oldest else 'metadata_created desc',
+            'sort': 'metadata_created ' + sort_order,
             'rows': rows,
             })
 

--- a/dedupe/deduper.py
+++ b/dedupe/deduper.py
@@ -219,9 +219,13 @@ class Deduper(object):
             log.debug('No duplicates found for identifier.')
             return 0
 
+        sort_order = 'asc' if self.oldest else 'desc'
         # We want to keep the oldest dataset
         self.log.debug('Fetching %s dataset for identifier=%s', 'oldest' if self.oldest else 'newest', identifier)
-        retained_dataset = self.ckan_api.get_dataset_to_save(self.organization_name, identifier, is_collection, oldest=self.oldest)
+        retained_dataset = self.ckan_api.get_dataset(self.organization_name,
+                                                     identifier,
+                                                     is_collection,
+                                                     sort_order=sort_order)
 
         # Check if the dedupe process has been started on this package
         if not util.get_package_extra(retained_dataset, 'datagov_dedupe'):

--- a/dedupe/tests/test_ckan_api.py
+++ b/dedupe/tests/test_ckan_api.py
@@ -47,4 +47,4 @@ class TestCkanApiClient(unittest.TestCase):
         with mock.patch.object(CkanApiClient, 'request', return_value=StubResponse(invalid_count_response)) as mock_request:
             api = CkanApiClient('http://test', 'api-key-abc')
             with self.assertRaises(CkanApiCountException):
-                api.get_dataset_to_save('test-organization', 'package-123', is_collection=False)
+                api.get_dataset('test-organization', 'package-123', is_collection=False)

--- a/dedupe/tests/test_ckan_api.py
+++ b/dedupe/tests/test_ckan_api.py
@@ -47,4 +47,4 @@ class TestCkanApiClient(unittest.TestCase):
         with mock.patch.object(CkanApiClient, 'request', return_value=StubResponse(invalid_count_response)) as mock_request:
             api = CkanApiClient('http://test', 'api-key-abc')
             with self.assertRaises(CkanApiCountException):
-                api.get_oldest_dataset('test-organization', 'package-123', is_collection=False)
+                api.get_dataset_to_save('test-organization', 'package-123', is_collection=False)

--- a/duplicates-identifier-api.py
+++ b/duplicates-identifier-api.py
@@ -52,7 +52,7 @@ def run():
     parser.add_argument('--commit', action='store_true',
                         help='Treat the API as writeable and commit the changes.')
     parser.add_argument('--newest', action='store_true',
-                        help='Keep the newest dataset and remove older ones (default keeps oldest')
+                        help='Keep the newest dataset and remove older ones (default keeps oldest)')
     parser.add_argument('--debug', action='store_true',
                         help='Include debug output from urllib3.')
     parser.add_argument('--run-id', default=datetime.now().strftime('%Y%m%d%H%M%S'),

--- a/duplicates-identifier-api.py
+++ b/duplicates-identifier-api.py
@@ -47,10 +47,12 @@ def run():
                                      'data.gov. By default, duplicates are detected but not '
                                      'actually removed.')
     parser.add_argument('--api-key', default=os.getenv('CKAN_API_KEY', None), help='Admin API key')
-    parser.add_argument('--api-url', default='https://admin-catalog.data.gov',
+    parser.add_argument('--api-url', default='https://admin-catalog-next.data.gov',
                         help='The API base URL to query')
     parser.add_argument('--commit', action='store_true',
                         help='Treat the API as writeable and commit the changes.')
+    parser.add_argument('--newest', action='store_true',
+                        help='Keep the newest dataset and remove older ones (default keeps oldest')
     parser.add_argument('--debug', action='store_true',
                         help='Include debug output from urllib3.')
     parser.add_argument('--run-id', default=datetime.now().strftime('%Y%m%d%H%M%S'),
@@ -104,7 +106,8 @@ def run():
             ckan_api,
             removed_package_log,
             duplicate_package_log,
-            run_id=args.run_id)
+            run_id=args.run_id,
+            oldest=not args.newest)
         deduper.dedupe()
 
 


### PR DESCRIPTION
Add command line option and necessary functionality to save the newest created/updated dataset and remove all older ones (default is to keep the oldest and remove others).
Related to https://github.com/GSA/datagov-deploy/issues/2981.

Tested on both NIST and EPA orgs, dataset duplicate counts and items to be removed match research in ticket when running with the `--newest` flag.