### PR TITLE
Handle dangling collection records

### DIFF
--- a/dedupe/ckan_api.py
+++ b/dedupe/ckan_api.py
@@ -142,6 +142,16 @@ class CkanApiClient(object):
 
         return response.json()['result']['count']
 
+    def get_datasets_in_collection(self, package_id):
+        filter_query = 'collection_package_id:%s' % package_id
+
+        response = self.get('/action/package_search', params={
+            'fq': filter_query,
+            'sort': 'metadata_created desc',
+            'rows': 0,
+            })
+        return response.json()['result']
+
     def get_datasets(self, organization_name, identifier, start=0, rows=1000,
                      is_collection=False):
         filter_query = \

--- a/dedupe/ckan_api.py
+++ b/dedupe/ckan_api.py
@@ -150,7 +150,11 @@ class CkanApiClient(object):
             'sort': 'metadata_created desc',
             'rows': 0,
             })
-        return response.json()['result']
+
+        search_result = response.json()['result']
+        if search_result['count'] > 0:
+            return search_result['results']
+        return None
 
     def get_datasets(self, organization_name, identifier, start=0, rows=1000,
                      is_collection=False):

--- a/dedupe/deduper.py
+++ b/dedupe/deduper.py
@@ -132,7 +132,6 @@ class Deduper(object):
 
         self.log.info('Summary duplicate_count=%d', total_duplicate_count)
 
-
     def remove_duplicate(self, duplicate_package, retained_package):
         self.log.info('Removing duplicate package=%r',
                       (duplicate_package['id'], duplicate_package['name']))
@@ -142,7 +141,25 @@ class Deduper(object):
         if self.duplicate_package_log:
             self.duplicate_package_log.add(duplicate_package, retained_package)
 
+        self.update_collection_datasets(duplicate_package, retained_package)
+
         self.ckan_api.remove_package(duplicate_package['id'])
+
+    def update_collection_datasets(self, duplicate_package, retained_package):
+        # Collection records may not have changed, and may be linked to the
+        #  dataset that is marked for removal. Update collection records
+        #  to point to the dataset that will be retained
+        collection_datasets = self.ckan_api.get_datasets_in_collection(duplicate_package['id'])
+        if collection_datasets['count'] > 0:
+            self.log.info('Updating collection records for dataset=%r',
+                          (duplicate_package['id'], duplicate_package['name']))
+            for cd in collection_datasets['results']:
+                self.log.info('Updating record %s', cd['title'])
+                for e in cd['extras']:
+                    if e['key'] == "collection_package_id":
+                        e.value = retained_package['id']
+                        break
+                self.ckan_api.update_package(cd)
 
     def mark_retained_package(self, retained_package):
         '''


### PR DESCRIPTION
Collection records are updated when the root dataset is removed.

Related to https://github.com/GSA/datagov-deploy/issues/2854