### PR TITLE
Run update on name after cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ $ pipenv run python duplicates-identifier-api.py --help
 usage: duplicates-identifier-api.py [-h] [--api-key API_KEY]
                                     [--api-url API_URL] [--commit] [--debug]
                                     [--run-id RUN_ID] [--verbose]
+                                    [--newest] [--update-name]
                                     [organization_name [organization_name ...]]
 
 Detects and removes duplicate packages on data.gov. By default, duplicates are
@@ -42,6 +43,9 @@ optional arguments:
                      script.
   --newest           Keep the newest dataset and remove older ones 
                      (by default the oldest is kept)
+  --update-name      Update the name of the kept package to be the standard
+                     shortest name, whether that was the duplicate package
+                     name or the to be kept package name.
   --verbose, -v      Include verbose log output.
 ```
 

--- a/dedupe/ckan_api.py
+++ b/dedupe/ckan_api.py
@@ -181,7 +181,7 @@ class CkanApiClient(object):
             log.info('Not removing package in dry_run package=%s', package_id)
             return
 
-        self.request('POST', '/action/package_delete', json={
+        self.request('POST', '/action/dataset_purge', json={
             'id': package_id,
         })
 

--- a/dedupe/deduper.py
+++ b/dedupe/deduper.py
@@ -152,7 +152,7 @@ class Deduper(object):
             #  the end of the name, we want to rename it to the "standard"
             #  name to keep the typical URL. 
             self.log.info('Renaming kept package from %s to %s',
-                      (retained_package['name'], duplicate_package['name']))
+                      retained_package['name'], duplicate_package['name'])
             retained_package['name'] = duplicate_package['name']
             self.ckan_api.update_package(retained_package)
             if self.removed_package_log:

--- a/dedupe/deduper.py
+++ b/dedupe/deduper.py
@@ -33,7 +33,8 @@ class Deduper(object):
                  duplicate_package_log=None,
                  collection_package_log=None,
                  run_id=None,
-                 oldest=True):
+                 oldest=True,
+                 update_name=False):
         self.organization_name = organization_name
         self.ckan_api = ckan_api
         self.log = ContextLoggerAdapter(module_log, {'organization': organization_name})
@@ -42,6 +43,7 @@ class Deduper(object):
         self.collection_package_log = collection_package_log
         self.stopped = False
         self.oldest = oldest
+        self.update_name = update_name
 
         if not run_id:
             run_id = datetime.now().strftime('%Y%m%d%H%M%S')
@@ -147,7 +149,8 @@ class Deduper(object):
 
         self.ckan_api.remove_package(duplicate_package['id'])
 
-        if(len(duplicate_package['name']) < len(retained_package['name'])):
+        if(len(duplicate_package['name']) < len(retained_package['name'])
+            and self.update_name ):
             # If the package to be retained has extra random character at
             #  the end of the name, we want to rename it to the "standard"
             #  name to keep the typical URL. 

--- a/dedupe/deduper.py
+++ b/dedupe/deduper.py
@@ -147,6 +147,17 @@ class Deduper(object):
 
         self.ckan_api.remove_package(duplicate_package['id'])
 
+        if(len(duplicate_package['name']) < len(retained_package['name'])):
+            # If the package to be retained has extra random character at
+            #  the end of the name, we want to rename it to the "standard"
+            #  name to keep the typical URL. 
+            self.log.info('Renaming kept package from %s to %s',
+                      (retained_package['name'], duplicate_package['name']))
+            retained_package['name'] = duplicate_package['name']
+            self.ckan_api.update_package(retained_package)
+            if self.removed_package_log:
+                self.removed_package_log.add(retained_package)
+
     def update_collection_datasets(self, duplicate_package, retained_package):
         # Collection records may not have changed, and may be linked to the
         #  dataset that is marked for removal. Update collection records

--- a/dedupe/tests/test_deduper.py
+++ b/dedupe/tests/test_deduper.py
@@ -26,15 +26,17 @@ class TestDeduper(unittest.TestCase):
             }]
         }]
         duplicate = {'id': '123', 'name': 'duplicate-package'}
-        retained = {'id': '456', 'name': 'retained-package'}
+        retained = {'id': '456', 'name': 'retained-package-12345'}
 
         self.deduper.remove_duplicate(duplicate, retained)
 
         self.duplicate_package_log.add.assert_called_once_with(duplicate, retained)
-        self.removed_package_log.add.assert_called_once_with(duplicate)
+        self.removed_package_log.add.assert_any_call(duplicate)
         self.ckan_api.remove_package.assert_called_once_with(duplicate['id'])
 
         self.collection_package_log.add.assert_called_once_with(retained['id'])
+        retained['name'] = duplicate['name']
+        self.removed_package_log.add.assert_called_with(retained)
 
     def test_mark_retained_package(self):
         identifier = 'harvest-identifier-1'

--- a/dedupe/tests/test_deduper.py
+++ b/dedupe/tests/test_deduper.py
@@ -15,7 +15,7 @@ class TestDeduper(unittest.TestCase):
         self.collection_package_log = mock.Mock(RemovedPackageLog)
 
         self.ckan_api = mock.Mock(CkanApiClient)
-        self.deduper = Deduper('test-org', self.ckan_api, removed_package_log=self.removed_package_log, duplicate_package_log=self.duplicate_package_log, collection_package_log=self.collection_package_log)
+        self.deduper = Deduper('test-org', self.ckan_api, removed_package_log=self.removed_package_log, duplicate_package_log=self.duplicate_package_log, collection_package_log=self.collection_package_log, update_name=True)
 
     def test_remove_duplicate(self):
         self.ckan_api.get_datasets_in_collection.return_value = [{
@@ -26,17 +26,25 @@ class TestDeduper(unittest.TestCase):
             }]
         }]
         duplicate = {'id': '123', 'name': 'duplicate-package'}
-        retained = {'id': '456', 'name': 'retained-package-12345'}
+        retained = {'id': '456', 'name': 'retained-package'}
 
         self.deduper.remove_duplicate(duplicate, retained)
 
         self.duplicate_package_log.add.assert_called_once_with(duplicate, retained)
-        self.removed_package_log.add.assert_any_call(duplicate)
+        self.removed_package_log.add.assert_called_once_with(duplicate)
         self.ckan_api.remove_package.assert_called_once_with(duplicate['id'])
 
         self.collection_package_log.add.assert_called_once_with(retained['id'])
-        retained['name'] = duplicate['name']
-        self.removed_package_log.add.assert_called_with(retained)
+
+    def test_update_name(self):
+        self.ckan_api.get_datasets_in_collection.return_value = []
+        name_extra_characters = {'id': 'to-be-kept', 'name': 'normal-name-12345'}
+        normal_name = {'id': 'duplicate', 'name': 'normal-name'}
+
+        # The normal name is considered the duplicate in this case
+        self.deduper.remove_duplicate(normal_name, name_extra_characters)
+        # Validate that the to-be-kept
+        self.removed_package_log.add.assert_called_with({'id': 'to-be-kept', 'name': 'normal-name'})
 
     def test_mark_retained_package(self):
         identifier = 'harvest-identifier-1'

--- a/duplicates-identifier-api.py
+++ b/duplicates-identifier-api.py
@@ -54,7 +54,7 @@ def run():
     parser.add_argument('--newest', action='store_true',
                         help='Keep the newest dataset and remove older ones (default keeps oldest)')
     parser.add_argument('--update-name', action='store_true',
-                        help='Update the name of the kept package to be the standard shortest name, whether that was the duplicate package name or the to be kept package name')
+                        help='Update the name of the kept package to be the standard shortest name, whether that was the duplicate package name or the to be kept package name.')
     parser.add_argument('--debug', action='store_true',
                         help='Include debug output from urllib3.')
     parser.add_argument('--run-id', default=datetime.now().strftime('%Y%m%d%H%M%S'),

--- a/duplicates-identifier-api.py
+++ b/duplicates-identifier-api.py
@@ -53,6 +53,8 @@ def run():
                         help='Treat the API as writeable and commit the changes.')
     parser.add_argument('--newest', action='store_true',
                         help='Keep the newest dataset and remove older ones (default keeps oldest)')
+    parser.add_argument('--update-name', action='store_true',
+                        help='Update the name of the kept package to be the standard shortest name, whether that was the duplicate package name or the to be kept package name')
     parser.add_argument('--debug', action='store_true',
                         help='Include debug output from urllib3.')
     parser.add_argument('--run-id', default=datetime.now().strftime('%Y%m%d%H%M%S'),
@@ -107,7 +109,8 @@ def run():
             removed_package_log,
             duplicate_package_log,
             run_id=args.run_id,
-            oldest=not args.newest)
+            oldest=not args.newest,
+            update_name=args.update_name)
         deduper.dedupe()
 
 


### PR DESCRIPTION
Sometimes the duplicate we *need* to keep that is in the db is the name
with the extra characters at the end. This checks for that, and tries
to use the simplest name possible in the one that we keep.

Related to recent duplicates on DOI harvest of DCAT-US metadata.

We need to purge and not just delete datasets for 2 reasons: we use this script to manage datasets and we don't have a reason to keep them around in a "deleted" state if they are a duplicate, and we cannot use the "correct" name without purging the duplicate dataset.