### PR TITLE
Feature/dup by source

### DIFF
--- a/.github/workflows/check_harvest_source_duplicates.yml
+++ b/.github/workflows/check_harvest_source_duplicates.yml
@@ -1,0 +1,24 @@
+---
+name: Check harvest source duplicates
+
+on:
+  workflow_dispatch:
+
+jobs:
+  check_harvest_source_duplicates:
+    name: Check Harvest Source Duplicates
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: Install pipenv
+        run: pip install pipenv
+      - name: build
+        run: pipenv sync
+      - name: run check
+        run: pipenv run python duplicate-packages-organization.py --harvest_sources --run-id=test
+      - name: save file
+        uses: actions/upload-artifact@v2
+        with:
+          name: harvest_overview
+          path: harvest-duplicates-test.csv

--- a/.github/workflows/check_harvest_source_duplicates.yml
+++ b/.github/workflows/check_harvest_source_duplicates.yml
@@ -1,7 +1,7 @@
 ---
 name: Check harvest source duplicates
 
-on:
+on:   # yamllint disable-line rule:truthy
   workflow_dispatch:
 
 jobs:
@@ -10,15 +10,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install pipenv
         run: pip install pipenv
       - name: build
         run: pipenv sync
       - name: run check
-        run: pipenv run python duplicate-packages-organization.py --harvest_sources --run-id=test
+        run: >
+          pipenv run python duplicate-packages-organization.py
+          --harvest_sources
+          --run-id=test
       - name: save file
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: harvest_overview
           path: harvest-duplicates-test.csv

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 duplicate-packages-*.csv
 removed-packages-*.log
 org-duplicates-*.csv
+harvest-duplicates-*.csv
 *.bak
 output.log

--- a/dedupe/ckan_api.py
+++ b/dedupe/ckan_api.py
@@ -1,12 +1,12 @@
-
 from __future__ import absolute_import
+
 import logging
 
 import requests
 
 log = logging.getLogger(__name__)
 
-READ_ONLY_METHODS = ['GET']
+READ_ONLY_METHODS = ["GET"]
 
 
 class CkanApiException(Exception):
@@ -16,44 +16,55 @@ class CkanApiException(Exception):
 
 
 class CkanApiFailureException(CkanApiException):
-    '''
+    """
     CKAN API reported {success: false}. It should be okay to continue using the API.
-    '''
+    """
+
     pass
 
 
 class CkanApiStatusException(CkanApiException):
-    '''
+    """
     CKAN API returned an unhealthy status code. This indicates something might
     not be working correctly with our configuration or the server could be
     having issues and we should not continue using the API in this state.
-    '''
+    """
+
     pass
 
 
 class CkanApiCountException(CkanApiException):
-    '''
+    """
     CKAN API (and solr) returned a non-zero count, but no data. Could this be
     solr index corruption?
-    '''
+    """
+
     pass
 
 
 class DryRunException(Exception):
-    '''
+    """
     Something happened during a dry-run execution that shouldn't have, like
     trying to write to the API.
-    '''
+    """
+
     pass
 
 
 class CkanApiClient(object):
-    '''
+    """
     Represents a client to query and submit requests to the CKAN API.
-    '''
+    """
 
-    def __init__(self, api_url, api_key, dry_run=True,
-                 identifier_type='identifier', api_read_url=None, reverse=False):
+    def __init__(
+        self,
+        api_url,
+        api_key,
+        dry_run=True,
+        identifier_type="identifier",
+        api_read_url=None,
+        reverse=False,
+    ):
         self.api_url = api_url
         if api_read_url is None:
             self.api_read_url = api_url
@@ -63,86 +74,111 @@ class CkanApiClient(object):
         self.reverse = reverse
         self.client = requests.Session()
         adapter = requests.adapters.HTTPAdapter(max_retries=3)
-        self.client.mount('https://', adapter)
+        self.client.mount("https://", adapter)
         self.client.headers.update(Authorization=api_key)
         # Set the auth_tkt cookie to talk to admin API
-        self.client.cookies = requests.cookies.cookiejar_from_dict(dict(auth_tkt='1'))
+        self.client.cookies = requests.cookies.cookiejar_from_dict(dict(auth_tkt="1"))
         self.identifier_type = identifier_type
 
     def request(self, method, path, **kwargs):
-        if method == 'POST':
-            url = '%s/api%s' % (self.api_url, path)
+        if method == "POST":
+            url = "%s/api%s" % (self.api_url, path)
         else:
-            url = '%s/api%s' % (self.api_read_url, path)
+            url = "%s/api%s" % (self.api_read_url, path)
 
         if self.dry_run and method not in READ_ONLY_METHODS:
-            raise DryRunException('Cannot call method in dry_run method=%s' % method)
+            raise DryRunException("Cannot call method in dry_run method=%s" % method)
 
         # Set a 60 second timeout for connections
-        kwargs.setdefault('timeout', 60)
+        kwargs.setdefault("timeout", 60)
 
         response = self.client.request(method, url, **kwargs)
         if response.status_code >= 400:
-            log.error('Unsuccessful status code status=%d body=%s', response.status_code, response.content)
-            raise CkanApiStatusException('Unsuccessful status code %d' % response.status_code, response)
+            log.error(
+                "Unsuccessful status code status=%d body=%s",
+                response.status_code,
+                response.content,
+            )
+            raise CkanApiStatusException(
+                "Unsuccessful status code %d" % response.status_code, response
+            )
 
-        if not response.json().get('success', False):
-            log.error('API failure status=%d body=%s', response.status_code, response.content)
-            raise CkanApiFailureException('API reported failure', response)
+        if not response.json().get("success", False):
+            log.error(
+                "API failure status=%d body=%s", response.status_code, response.content
+            )
+            raise CkanApiFailureException("API reported failure", response)
 
         return response
 
     def get(self, path, **kwargs):
-        return self.request('GET', path, **kwargs)
+        return self.request("GET", path, **kwargs)
 
-    def get_dataset(self, organization_name, identifier, is_collection, sort_order='asc'):
-        filter_query = \
-            '%s:"%s" AND organization:"%s" AND type:dataset' % \
-            (self.identifier_type, identifier, organization_name)
+    def get_dataset(
+        self, organization_name, identifier, is_collection, sort_order="asc"
+    ):
+        filter_query = '%s:"%s" AND organization:"%s" AND type:dataset' % (
+            self.identifier_type,
+            identifier,
+            organization_name,
+        )
         if is_collection:
-            filter_query = '%s AND collection_package_id:*' % filter_query
+            filter_query = "%s AND collection_package_id:*" % filter_query
 
         rows = 1
-        response = self.get('/action/package_search', params={
-            'fq': filter_query,
-            'sort': 'metadata_created ' + sort_order,
-            'rows': rows,
-        })
+        response = self.get(
+            "/action/package_search",
+            params={
+                "fq": filter_query,
+                "sort": "metadata_created " + sort_order,
+                "rows": rows,
+            },
+        )
 
-        results = response.json()['result']['results']
+        results = response.json()["result"]["results"]
 
         if len(results) != rows:
-            count = response.json()['result']['count']
+            count = response.json()["result"]["count"]
             raise CkanApiCountException(
-                'Query reported non-zero count but no data '
-                'count=%(count)s results=%(results)s' % {
-                    'count': count,
-                    'results': len(results),
+                "Query reported non-zero count but no data "
+                "count=%(count)s results=%(results)s"
+                % {
+                    "count": count,
+                    "results": len(results),
                 },
-                response)
+                response,
+            )
 
         return results[0]
 
     def check_dataset(self, name):
-        response = self.get('/action/package_show', params={
-            'id': name,
-            })
-        return response.json()['result']
+        response = self.get(
+            "/action/package_show",
+            params={
+                "id": name,
+            },
+        )
+        return response.json()["result"]
 
-    def get_duplicate_identifiers(self, organization_name, is_collection, full_count=False):
+    def get_duplicate_identifiers(
+        self, organization_name, is_collection, full_count=False
+    ):
         filter_query = 'organization:"%s" AND type:dataset' % organization_name
         if is_collection:
-            filter_query = '%s AND collection_package_id:*' % filter_query
+            filter_query = "%s AND collection_package_id:*" % filter_query
 
-        response = self.get('/3/action/package_search', params={
-            'fq': filter_query,
-            'facet.field': '["' + self.identifier_type + '"]',
-            'facet.limit': -1,
-            'facet.mincount': 2,
-            'rows': 0,
-        })
+        response = self.get(
+            "/3/action/package_search",
+            params={
+                "fq": filter_query,
+                "facet.field": '["' + self.identifier_type + '"]',
+                "facet.limit": -1,
+                "facet.mincount": 2,
+                "rows": 0,
+            },
+        )
 
-        dupes = response.json()['result']['facets'][self.identifier_type]
+        dupes = response.json()["result"]["facets"][self.identifier_type]
 
         # If we want not just the identifiers, but also the counts
         if full_count:
@@ -151,120 +187,156 @@ class CkanApiClient(object):
         # If you want to run 2 scripts in parallel, run one version with normal sort
         # and another with `--reverse` flag
         return sorted(dupes, reverse=self.reverse)
-    
-    def get_duplicate_identifiers_source(self, harvest_source_title, is_collection, full_count=False):
-        filter_query = 'harvest_source_title:"%s" AND type:dataset' % harvest_source_title
+
+    def get_duplicate_identifiers_source(
+        self, harvest_source_title, is_collection, full_count=False
+    ):
+        filter_query = (
+            'harvest_source_title:"%s" AND type:dataset' % harvest_source_title
+        )
         if is_collection:
-            filter_query = '%s AND collection_package_id:*' % filter_query
+            filter_query = "%s AND collection_package_id:*" % filter_query
 
-        response = self.get('/3/action/package_search', params={
-            'fq': filter_query,
-            'facet.field': '["' + self.identifier_type + '"]',
-            'facet.limit': -1,
-            'facet.mincount': 2,
-            'rows': 0,
-        })
+        response = self.get(
+            "/3/action/package_search",
+            params={
+                "fq": filter_query,
+                "facet.field": '["' + self.identifier_type + '"]',
+                "facet.limit": -1,
+                "facet.mincount": 2,
+                "rows": 0,
+            },
+        )
 
-        dupes = response.json()['result']['facets'][self.identifier_type]
+        dupes = response.json()["result"]["facets"][self.identifier_type]
 
         # If we want not just the identifiers, but also the counts
         if full_count:
             return dupes
 
     def get_dataset_count(self, organization_name, identifier, is_collection):
-        filter_query = \
-            '%s:"%s" AND organization:"%s" AND type:dataset' % \
-            (self.identifier_type, identifier, organization_name)
+        filter_query = '%s:"%s" AND organization:"%s" AND type:dataset' % (
+            self.identifier_type,
+            identifier,
+            organization_name,
+        )
         if is_collection:
-            filter_query = '%s AND collection_package_id:*' % filter_query
+            filter_query = "%s AND collection_package_id:*" % filter_query
 
-        response = self.get('/action/package_search', params={
-            'fq': filter_query,
-            'sort': 'metadata_created desc',
-            'rows': 0,
-        })
+        response = self.get(
+            "/action/package_search",
+            params={
+                "fq": filter_query,
+                "sort": "metadata_created desc",
+                "rows": 0,
+            },
+        )
 
-        return response.json()['result']['count']
+        return response.json()["result"]["count"]
 
     def get_datasets_in_collection(self, package_id):
-        filter_query = 'collection_package_id:%s' % package_id
+        filter_query = "collection_package_id:%s" % package_id
 
-        response = self.get('/action/package_search', params={
-            'fq': filter_query,
-            'sort': 'metadata_created desc',
-            'rows': 0,
-        })
+        response = self.get(
+            "/action/package_search",
+            params={
+                "fq": filter_query,
+                "sort": "metadata_created desc",
+                "rows": 0,
+            },
+        )
 
-        search_result = response.json()['result']
-        if search_result['count'] > 0:
-            return search_result['results']
+        search_result = response.json()["result"]
+        if search_result["count"] > 0:
+            return search_result["results"]
         return None
 
-    def get_datasets(self, organization_name, identifier, start=0, rows=1000,
-                     is_collection=False):
-        filter_query = \
-            '%s:"%s" AND organization:"%s" AND type:dataset' % \
-            (self.identifier_type, identifier, organization_name)
+    def get_datasets(
+        self, organization_name, identifier, start=0, rows=1000, is_collection=False
+    ):
+        filter_query = '%s:"%s" AND organization:"%s" AND type:dataset' % (
+            self.identifier_type,
+            identifier,
+            organization_name,
+        )
         if is_collection:
-            filter_query = '%s AND collection_package_id:*' % filter_query
+            filter_query = "%s AND collection_package_id:*" % filter_query
 
-        response = self.get('/action/package_search', params={
-            'fq': filter_query,
-            'start': start,
-            'rows': rows,
-        })
+        response = self.get(
+            "/action/package_search",
+            params={
+                "fq": filter_query,
+                "start": start,
+                "rows": rows,
+            },
+        )
 
-        return response.json()['result']['results']
+        return response.json()["result"]["results"]
 
-    def get_all_datasets(self, start=0, rows=1000, organization='*',
-                     is_collection=False):
+    def get_all_datasets(
+        self, start=0, rows=1000, organization="*", is_collection=False
+    ):
         filter_query = f"type:dataset AND organization:{organization}"
 
-        response = self.get('/action/package_search', params={
-            'fq': filter_query,
-            'start': start,
-            'rows': rows,
-            })
+        response = self.get(
+            "/action/package_search",
+            params={
+                "fq": filter_query,
+                "start": start,
+                "rows": rows,
+            },
+        )
 
-        return response.json()['result']['results']
+        return response.json()["result"]["results"]
 
     def get_organizations(self):
-        response = self.get('/action/organization_list')
-        return response.json()['result']
+        response = self.get("/action/organization_list")
+        return response.json()["result"]
 
     def get_harvest_sources(self):
         start = 0
         harvest_sources = []
         while True:
-            response = self.get(f'/action/package_search?fq=dataset_type:harvest&rows=1000&start={start}')
-            harvest_sources += response.json()['result']['results']
-            if(response.json()['result']['count'] <= start + 1000):
+            response = self.get(
+                f"/action/package_search?fq=dataset_type:harvest&rows=1000&start={start}"
+            )
+            harvest_sources += response.json()["result"]["results"]
+            if response.json()["result"]["count"] <= start + 1000:
                 break
             else:
                 start += 1000
-            
+
         return harvest_sources
 
     def get_organization_count(self, organization_name):
-        response = self.get('/action/package_search?q=organization:%s&rows=0' % organization_name)
-        return response.json()['result']['count']
-    
+        response = self.get(
+            "/action/package_search?q=organization:%s&rows=0" % organization_name
+        )
+        return response.json()["result"]["count"]
+
     def get_harvest_source_count(self, harvest_source_title):
-        response = self.get('/action/package_search?q=harvest_source_title:"%s"&rows=0' % harvest_source_title)
-        return response.json()['result']['count']
+        response = self.get(
+            '/action/package_search?q=harvest_source_title:"%s"&rows=0'
+            % harvest_source_title
+        )
+        return response.json()["result"]["count"]
 
     def remove_package(self, package_id):
         if self.dry_run:
-            log.info('Not removing package in dry_run package=%s', package_id)
+            log.info("Not removing package in dry_run package=%s", package_id)
             return
 
-        self.request('POST', '/action/dataset_purge', json={
-            'id': package_id,
-        })
+        self.request(
+            "POST",
+            "/action/dataset_purge",
+            json={
+                "id": package_id,
+            },
+        )
 
     def update_package(self, package):
         if self.dry_run:
-            log.info('Not updating package in dry_run package=%s', package['id'])
+            log.info("Not updating package in dry_run package=%s", package["id"])
             return
 
-        self.request('POST', '/action/package_update', json=package)
+        self.request("POST", "/action/package_update", json=package)

--- a/dedupe/ckan_api.py
+++ b/dedupe/ckan_api.py
@@ -233,8 +233,17 @@ class CkanApiClient(object):
         return response.json()['result']
 
     def get_harvest_sources(self):
-        response = self.get('/action/package_search?fq=dataset_type:harvest&rows=10000')
-        return response.json()['result']['results']
+        start = 0
+        harvest_sources = []
+        while True:
+            response = self.get(f'/action/package_search?fq=dataset_type:harvest&rows=1000&start={start}')
+            harvest_sources += response.json()['result']['results']
+            if(response.json()['result']['count'] <= start + 1000):
+                break
+            else:
+                start += 1000
+            
+        return harvest_sources
 
     def get_organization_count(self, organization_name):
         response = self.get('/action/package_search?q=organization:%s&rows=0' % organization_name)

--- a/duplicate-packages-organization.py
+++ b/duplicate-packages-organization.py
@@ -1,14 +1,14 @@
-
 from __future__ import absolute_import
+
 import argparse
 import csv
-from datetime import datetime
 import itertools
 import logging
 import logging.config
 import os
 import sys
 import time
+from datetime import datetime
 
 from dedupe.ckan_api import CkanApiClient
 
@@ -16,35 +16,40 @@ from dedupe.ckan_api import CkanApiClient
 class OrgDuplicateLog(object):
     # Order matters here for the report
     fieldnames = [
-        'name',                           # Organization Name
-        'number_datasets_duplicated',     # Duplicate identifiers (CKAN ID)
-        'total_duplicate_count',          # Sum of all duplicates
-        'total_datasets',                 # Number of datasets in org
-        'percent_duplicate',              # Amount of org datasets are dupes
+        "name",  # Organization Name
+        "number_datasets_duplicated",  # Duplicate identifiers (CKAN ID)
+        "total_duplicate_count",  # Sum of all duplicates
+        "total_datasets",  # Number of datasets in org
+        "percent_duplicate",  # Amount of org datasets are dupes
     ]
 
     def __init__(self, filename=None, run_id=None):
         if not run_id:
-            run_id = datetime.now().strftime('%Y%m%d%H%M%S')
+            run_id = datetime.now().strftime("%Y%m%d%H%M%S")
 
         if not filename:
-            filename = 'org-duplicates-%s.csv' % run_id
+            filename = "org-duplicates-%s.csv" % run_id
 
-        log.info('Opening duplicate package report for writing filename=%s', filename)
-        self.__f = open(filename, mode='w')
-        self.log = csv.DictWriter(self.__f,
-                                  fieldnames=OrgDuplicateLog.fieldnames)
+        log.info("Opening duplicate package report for writing filename=%s", filename)
+        self.__f = open(filename, mode="w")
+        self.log = csv.DictWriter(self.__f, fieldnames=OrgDuplicateLog.fieldnames)
         self.log.writeheader()
 
     def add(self, org_results):
-        log.debug('Recording organization counts=%s', org_results.get('organization_name'))
-        self.log.writerow({
-            'name': org_results.get('name'),
-            'number_datasets_duplicated': org_results.get('number_datasets_duplicated'),
-            'total_duplicate_count': org_results.get('total_duplicate_count'),
-            'total_datasets': org_results.get('total_datasets'),
-            'percent_duplicate': org_results.get('percent_duplicate'),
-        })
+        log.debug(
+            "Recording organization counts=%s", org_results.get("organization_name")
+        )
+        self.log.writerow(
+            {
+                "name": org_results.get("name"),
+                "number_datasets_duplicated": org_results.get(
+                    "number_datasets_duplicated"
+                ),
+                "total_duplicate_count": org_results.get("total_duplicate_count"),
+                "total_datasets": org_results.get("total_datasets"),
+                "percent_duplicate": org_results.get("percent_duplicate"),
+            }
+        )
 
         # Persist the write to disk
         self.__f.flush()
@@ -54,45 +59,52 @@ class OrgDuplicateLog(object):
 class HarvestDuplicateLog(object):
     # Order matters here for the report
     fieldnames = [
-        'harvest_name',                   # Harvest Source Name
-        'org_name',                       # Organization Name
-        'number_datasets_duplicated',     # Duplicate identifiers (CKAN ID)
-        'total_duplicate_count',          # Sum of all duplicates
-        'total_datasets',                 # Number of datasets in org
-        'percent_duplicate',              # Amount of org datasets are dupes
+        "harvest_name",  # Harvest Source Name
+        "org_name",  # Organization Name
+        "number_datasets_duplicated",  # Duplicate identifiers (CKAN ID)
+        "total_duplicate_count",  # Sum of all duplicates
+        "total_datasets",  # Number of datasets in org
+        "percent_duplicate",  # Amount of org datasets are dupes
     ]
 
     def __init__(self, filename=None, run_id=None):
         if not run_id:
-            run_id = datetime.now().strftime('%Y%m%d%H%M%S')
+            run_id = datetime.now().strftime("%Y%m%d%H%M%S")
 
         if not filename:
-            filename = 'harvest-duplicates-%s.csv' % run_id
+            filename = "harvest-duplicates-%s.csv" % run_id
 
-        log.info('Opening duplicate package report for writing filename=%s', filename)
-        self.__f = open(filename, mode='w')
-        self.log = csv.DictWriter(self.__f,
-                                  fieldnames=HarvestDuplicateLog.fieldnames)
+        log.info("Opening duplicate package report for writing filename=%s", filename)
+        self.__f = open(filename, mode="w")
+        self.log = csv.DictWriter(self.__f, fieldnames=HarvestDuplicateLog.fieldnames)
         self.log.writeheader()
 
     def add(self, harvest_results):
-        log.debug('Recording organization counts=%s', harvest_results.get('organization_name'))
-        self.log.writerow({
-            'harvest_name': harvest_results.get('harvest_name'),
-            'org_name': harvest_results.get('org_name'),
-            'number_datasets_duplicated': harvest_results.get('number_datasets_duplicated'),
-            'total_duplicate_count': harvest_results.get('total_duplicate_count'),
-            'total_datasets': harvest_results.get('total_datasets'),
-            'percent_duplicate': harvest_results.get('percent_duplicate'),
-        })
+        log.debug(
+            "Recording organization counts=%s", harvest_results.get("organization_name")
+        )
+        self.log.writerow(
+            {
+                "harvest_name": harvest_results.get("harvest_name"),
+                "org_name": harvest_results.get("org_name"),
+                "number_datasets_duplicated": harvest_results.get(
+                    "number_datasets_duplicated"
+                ),
+                "total_duplicate_count": harvest_results.get("total_duplicate_count"),
+                "total_datasets": harvest_results.get("total_datasets"),
+                "percent_duplicate": harvest_results.get("percent_duplicate"),
+            }
+        )
 
         # Persist the write to disk
         self.__f.flush()
         os.fsync(self.__f.fileno())
 
 
-logging.basicConfig(stream=sys.stdout, format='%(asctime)s [%(name)s] %(levelname)s: %(message)s')
-log = logging.getLogger('dedupe')
+logging.basicConfig(
+    stream=sys.stdout, format="%(asctime)s [%(name)s] %(levelname)s: %(message)s"
+)
+log = logging.getLogger("dedupe")
 log.setLevel(logging.INFO)
 
 # Define module-level context for signal handling
@@ -101,48 +113,63 @@ deduper = None
 
 
 def get_org_list(ckan):
-    log.debug('Fetching organizations...')
+    log.debug("Fetching organizations...")
     organizations_list = ckan.get_organizations()
 
-    log.debug('Found organizations count=%d', len(organizations_list))
+    log.debug("Found organizations count=%d", len(organizations_list))
     return organizations_list
 
 
 def get_harvest_sources(ckan):
-    log.debug('Fetching organizations...')
+    log.debug("Fetching organizations...")
     harvest_sources_list = ckan.get_harvest_sources()
 
-    log.debug('Found organizations count=%d', len(harvest_sources_list))
+    log.debug("Found organizations count=%d", len(harvest_sources_list))
     return harvest_sources_list
+
 
 def cleanup(signum, frame):
     global deduper, stopped
-    log.warning('Stopping any in-progress dedupers...')
+    log.warning("Stopping any in-progress dedupers...")
     stopped = True
     deduper.stop()
 
 
 def run():
-    '''
+    """
     This code for getting the list of organizations and duplicate duplicate data sets
-    '''
+    """
     global deduper, stopped
 
-    parser = argparse.ArgumentParser(description='Detects and removes duplicate packages on '
-                                     'data.gov. By default, duplicates are detected but not '
-                                     'actually removed.')
-    parser.add_argument('--api-url', default='https://catalog.data.gov',
-                        help='The API base URL to query')
-    parser.add_argument('--debug', action='store_true',
-                        help='Include debug output from urllib3.')
-    parser.add_argument('--run-id', default=datetime.now().strftime('%Y%m%d%H%M%S'),
-                        help='An identifier for a single run of the deduplication script.')
-    parser.add_argument('--verbose', '-v', action='store_true',
-                        help='Include verbose log output.')
-    parser.add_argument('organization_name', nargs='*',
-                        help='Names of the organizations to deduplicate.')
-    parser.add_argument('--harvest_sources', action='store_true',
-                        help='Get counts by harvest source')
+    parser = argparse.ArgumentParser(
+        description="Detects and removes duplicate packages on "
+        "data.gov. By default, duplicates are detected but not "
+        "actually removed."
+    )
+    parser.add_argument(
+        "--api-url",
+        default="https://catalog.data.gov",
+        help="The API base URL to query",
+    )
+    parser.add_argument(
+        "--debug", action="store_true", help="Include debug output from urllib3."
+    )
+    parser.add_argument(
+        "--run-id",
+        default=datetime.now().strftime("%Y%m%d%H%M%S"),
+        help="An identifier for a single run of the deduplication script.",
+    )
+    parser.add_argument(
+        "--verbose", "-v", action="store_true", help="Include verbose log output."
+    )
+    parser.add_argument(
+        "organization_name",
+        nargs="*",
+        help="Names of the organizations to deduplicate.",
+    )
+    parser.add_argument(
+        "--harvest_sources", action="store_true", help="Get counts by harvest source"
+    )
 
     args = parser.parse_args()
 
@@ -150,21 +177,21 @@ def run():
         log.setLevel(logging.DEBUG)
 
     if args.debug:
-        logging.getLogger('urllib3').setLevel(logging.DEBUG)
+        logging.getLogger("urllib3").setLevel(logging.DEBUG)
 
-    log.info('run_id=%s', args.run_id)
+    log.info("run_id=%s", args.run_id)
 
-    ckan_api = CkanApiClient(args.api_url, "None", identifier_type='identifier')
-    ckan_geo_api = CkanApiClient(args.api_url, "None", identifier_type='guid')
+    ckan_api = CkanApiClient(args.api_url, "None", identifier_type="identifier")
+    ckan_geo_api = CkanApiClient(args.api_url, "None", identifier_type="guid")
 
-    log.info('Using api=%s', args.api_url)
+    log.info("Using api=%s", args.api_url)
 
     if args.harvest_sources:
         # Get and organize by harvest source
         harvest_log = HarvestDuplicateLog(run_id=args.run_id)
         harvest_sources = get_harvest_sources(ckan_api)
 
-        log.info('Checking %d harvest sources for duplicates', len(harvest_sources))
+        log.info("Checking %d harvest sources for duplicates", len(harvest_sources))
 
         # Loop over the harvest sources one at a time
         count = itertools.count(start=1)
@@ -174,8 +201,12 @@ def run():
             log.info("Checking harvest source=%s", s["title"])
             total = ckan_api.get_harvest_source_count(s["title"])
 
-            json_duplicates = ckan_api.get_duplicate_identifiers_source(s["title"], False, full_count=True)
-            geo_duplicates = ckan_geo_api.get_duplicate_identifiers_source(s["title"], False, full_count=True)
+            json_duplicates = ckan_api.get_duplicate_identifiers_source(
+                s["title"], False, full_count=True
+            )
+            geo_duplicates = ckan_geo_api.get_duplicate_identifiers_source(
+                s["title"], False, full_count=True
+            )
             duplicates = {**json_duplicates, **geo_duplicates}
             count = 0
 
@@ -188,12 +219,13 @@ def run():
                 "number_datasets_duplicated": len(duplicates),
                 "total_duplicate_count": count,
                 "total_datasets": total,
-                "percent_duplicate": round(float(count) / (total if total > 0 else 1) * 100, 2)
+                "percent_duplicate": round(
+                    float(count) / (total if total > 0 else 1) * 100, 2
+                ),
             }
 
             harvest_log.add(harvest_source_overview)
             time.sleep(1)
-
 
     else:
         # Get and organize by org
@@ -205,7 +237,7 @@ def run():
             # get all organizations that have datajson harvester
             org_list = get_org_list(ckan_api)
 
-        log.info('Checking %d organizations for duplicates', len(org_list))
+        log.info("Checking %d organizations for duplicates", len(org_list))
 
         # Loop over the organizations one at a time
         count = itertools.count(start=1)
@@ -215,8 +247,12 @@ def run():
             log.info("Checking org=%s", organization)
             total = ckan_api.get_organization_count(organization)
 
-            json_duplicates = ckan_api.get_duplicate_identifiers(organization, False, full_count=True)
-            geo_duplicates = ckan_geo_api.get_duplicate_identifiers(organization, False, full_count=True)
+            json_duplicates = ckan_api.get_duplicate_identifiers(
+                organization, False, full_count=True
+            )
+            geo_duplicates = ckan_geo_api.get_duplicate_identifiers(
+                organization, False, full_count=True
+            )
             # duplicates = json_duplicates.copy()
             # duplicates.update(geo_duplicates)
             duplicates = {**json_duplicates, **geo_duplicates}
@@ -231,7 +267,9 @@ def run():
                 "number_datasets_duplicated": len(duplicates),
                 "total_duplicate_count": count,
                 "total_datasets": total,
-                "percent_duplicate": round(float(count) / (total if total > 0 else 1) * 100, 2)
+                "percent_duplicate": round(
+                    float(count) / (total if total > 0 else 1) * 100, 2
+                ),
             }
 
             org_log.add(org_overview)

--- a/duplicate-packages-organization.py
+++ b/duplicate-packages-organization.py
@@ -8,6 +8,7 @@ import logging
 import logging.config
 import os
 import sys
+import time
 
 from dedupe.ckan_api import CkanApiClient
 
@@ -50,6 +51,46 @@ class OrgDuplicateLog(object):
         os.fsync(self.__f.fileno())
 
 
+class HarvestDuplicateLog(object):
+    # Order matters here for the report
+    fieldnames = [
+        'harvest_name',                   # Harvest Source Name
+        'org_name',                       # Organization Name
+        'number_datasets_duplicated',     # Duplicate identifiers (CKAN ID)
+        'total_duplicate_count',          # Sum of all duplicates
+        'total_datasets',                 # Number of datasets in org
+        'percent_duplicate',              # Amount of org datasets are dupes
+    ]
+
+    def __init__(self, filename=None, run_id=None):
+        if not run_id:
+            run_id = datetime.now().strftime('%Y%m%d%H%M%S')
+
+        if not filename:
+            filename = 'harvest-duplicates-%s.csv' % run_id
+
+        log.info('Opening duplicate package report for writing filename=%s', filename)
+        self.__f = open(filename, mode='w')
+        self.log = csv.DictWriter(self.__f,
+                                  fieldnames=HarvestDuplicateLog.fieldnames)
+        self.log.writeheader()
+
+    def add(self, harvest_results):
+        log.debug('Recording organization counts=%s', harvest_results.get('organization_name'))
+        self.log.writerow({
+            'harvest_name': harvest_results.get('harvest_name'),
+            'org_name': harvest_results.get('org_name'),
+            'number_datasets_duplicated': harvest_results.get('number_datasets_duplicated'),
+            'total_duplicate_count': harvest_results.get('total_duplicate_count'),
+            'total_datasets': harvest_results.get('total_datasets'),
+            'percent_duplicate': harvest_results.get('percent_duplicate'),
+        })
+
+        # Persist the write to disk
+        self.__f.flush()
+        os.fsync(self.__f.fileno())
+
+
 logging.basicConfig(stream=sys.stdout, format='%(asctime)s [%(name)s] %(levelname)s: %(message)s')
 log = logging.getLogger('dedupe')
 log.setLevel(logging.INFO)
@@ -66,6 +107,13 @@ def get_org_list(ckan):
     log.debug('Found organizations count=%d', len(organizations_list))
     return organizations_list
 
+
+def get_harvest_sources(ckan):
+    log.debug('Fetching organizations...')
+    harvest_sources_list = ckan.get_harvest_sources()
+
+    log.debug('Found organizations count=%d', len(harvest_sources_list))
+    return harvest_sources_list
 
 def cleanup(signum, frame):
     global deduper, stopped
@@ -93,6 +141,8 @@ def run():
                         help='Include verbose log output.')
     parser.add_argument('organization_name', nargs='*',
                         help='Names of the organizations to deduplicate.')
+    parser.add_argument('--harvest_sources', action='store_true',
+                        help='Get counts by harvest source')
 
     args = parser.parse_args()
 
@@ -107,46 +157,84 @@ def run():
     ckan_api = CkanApiClient(args.api_url, "None", identifier_type='identifier')
     ckan_geo_api = CkanApiClient(args.api_url, "None", identifier_type='guid')
 
-    org_log = OrgDuplicateLog(run_id=args.run_id)
-
     log.info('Using api=%s', args.api_url)
 
-    if args.organization_name:
-        org_list = args.organization_name
+    if args.harvest_sources:
+        # Get and organize by harvest source
+        harvest_log = HarvestDuplicateLog(run_id=args.run_id)
+        harvest_sources = get_harvest_sources(ckan_api)
+
+        log.info('Checking %d harvest sources for duplicates', len(harvest_sources))
+
+        # Loop over the harvest sources one at a time
+        count = itertools.count(start=1)
+        for s in harvest_sources:
+            if stopped:
+                break
+            log.info("Checking harvest source=%s", s["title"])
+            total = ckan_api.get_harvest_source_count(s["title"])
+
+            json_duplicates = ckan_api.get_duplicate_identifiers_source(s["title"], False, full_count=True)
+            geo_duplicates = ckan_geo_api.get_duplicate_identifiers_source(s["title"], False, full_count=True)
+            duplicates = {**json_duplicates, **geo_duplicates}
+            count = 0
+
+            for dupe_cnt in duplicates.values():
+                count += dupe_cnt - 1
+
+            harvest_source_overview = {
+                "harvest_name": s["title"],
+                "org_name": s["organization"]["title"],
+                "number_datasets_duplicated": len(duplicates),
+                "total_duplicate_count": count,
+                "total_datasets": total,
+                "percent_duplicate": round(float(count) / (total if total > 0 else 1) * 100, 2)
+            }
+
+            harvest_log.add(harvest_source_overview)
+            time.sleep(1)
+
+
     else:
-        # get all organizations that have datajson harvester
-        org_list = get_org_list(ckan_api)
+        # Get and organize by org
+        org_log = OrgDuplicateLog(run_id=args.run_id)
 
-    log.info('Checking %d organizations for duplicates', len(org_list))
+        if args.organization_name:
+            org_list = args.organization_name
+        else:
+            # get all organizations that have datajson harvester
+            org_list = get_org_list(ckan_api)
 
-    # Loop over the organizations one at a time
-    count = itertools.count(start=1)
-    for organization in org_list:
-        if stopped:
-            break
-        log.info("Checking org=%s", organization)
-        total = ckan_api.get_organization_count(organization)
+        log.info('Checking %d organizations for duplicates', len(org_list))
 
-        json_duplicates = ckan_api.get_duplicate_identifiers(organization, False, full_count=True)
-        geo_duplicates = ckan_geo_api.get_duplicate_identifiers(organization, False, full_count=True)
-        # duplicates = json_duplicates.copy()
-        # duplicates.update(geo_duplicates)
-        duplicates = {**json_duplicates, **geo_duplicates}
-        count = 0
+        # Loop over the organizations one at a time
+        count = itertools.count(start=1)
+        for organization in org_list:
+            if stopped:
+                break
+            log.info("Checking org=%s", organization)
+            total = ckan_api.get_organization_count(organization)
 
-        for dupe_cnt in duplicates.values():
-            count += dupe_cnt - 1
+            json_duplicates = ckan_api.get_duplicate_identifiers(organization, False, full_count=True)
+            geo_duplicates = ckan_geo_api.get_duplicate_identifiers(organization, False, full_count=True)
+            # duplicates = json_duplicates.copy()
+            # duplicates.update(geo_duplicates)
+            duplicates = {**json_duplicates, **geo_duplicates}
+            count = 0
 
-        org_overview = {
-            "title": "",
-            "name": organization,
-            "number_datasets_duplicated": len(duplicates),
-            "total_duplicate_count": count,
-            "total_datasets": total,
-            "percent_duplicate": round(float(count) / (total if total > 0 else 1) * 100, 2)
-        }
+            for dupe_cnt in duplicates.values():
+                count += dupe_cnt - 1
 
-        org_log.add(org_overview)
+            org_overview = {
+                "title": "",
+                "name": organization,
+                "number_datasets_duplicated": len(duplicates),
+                "total_duplicate_count": count,
+                "total_datasets": total,
+                "percent_duplicate": round(float(count) / (total if total > 0 else 1) * 100, 2)
+            }
+
+            org_log.add(org_overview)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
By request, get duplicates by harvest source.

Useful because often harvest sources are managed/organized by different people (even when coming from same organization), and helps the organization debug further.

@hkdctol this will be helpful in further discussions with NOAA.

Please note the sleep(1), as this hits the CKAN API too fast and causes 403 errors...