### PR TITLE
Use metadata_modified

### DIFF
--- a/dedupe/ckan_api.py
+++ b/dedupe/ckan_api.py
@@ -130,7 +130,7 @@ class CkanApiClient(object):
             "/action/package_search",
             params={
                 "fq": filter_query,
-                "sort": "metadata_created " + sort_order,
+                "sort": "metadata_modified " + sort_order,
                 "rows": rows,
             },
         )


### PR DESCRIPTION
keep the last modified package.

In the discussion for https://github.com/GSA/data.gov/issues/3968, using `metadata_modified` make better sense than `metadata_created`. 