### PR TITLE
Keep newest

### DIFF
--- a/.github/workflows/check_harvest_source_duplicates.yml
+++ b/.github/workflows/check_harvest_source_duplicates.yml
@@ -11,9 +11,9 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v3
-      - name: Set up Python 3.8
+      - name: Set up Python 3.12
         uses: actions/setup-python@v1
-        with: { python-version: 3.8 }
+        with: { python-version: 3.12 }
       - name: Install pip and pipenv
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/check_org_duplicates.yml
+++ b/.github/workflows/check_org_duplicates.yml
@@ -11,9 +11,9 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-      - name: Set up Python 3.8
+      - name: Set up Python 3.12
         uses: actions/setup-python@v1
-        with: { python-version: 3.8 }
+        with: { python-version: 3.12 }
       - name: Install pip and pipenv
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/run_dedupe.yml
+++ b/.github/workflows/run_dedupe.yml
@@ -161,9 +161,9 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-      - name: Set up Python 3.8
+      - name: Set up Python 3.12
         uses: actions/setup-python@v1
-        with: { python-version: 3.8 }
+        with: { python-version: 3.12 }
       - name: Install pip and pipenv
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/run_dedupe.yml
+++ b/.github/workflows/run_dedupe.yml
@@ -8,6 +8,14 @@ on:
         type: boolean
         description: Check if organization has geospatial duplicates
         required: true
+      keep:
+        type: choice
+        description: 'Keep'
+        required: true
+        default: 'newest'
+        options:
+        - newest
+        - oldest
       dryrun:
         type: boolean
         description: Only run the dryrun
@@ -176,6 +184,8 @@ jobs:
           if ${{ inputs.geospatial }}; then
             args="${args} --geospatial"
           fi
+          if ${{ inputs.keep == 'newest' }}; then
+            args="${args} --newest"
           if ! ${{ inputs.dryrun }}; then
             args="${args} --commit"
             args="${args} --api-key ${{secrets.CKAN_API_TOKEN}}"


### PR DESCRIPTION
For https://github.com/GSA/data.gov/issues/5016

Introduce an option to keep the newest/oldest package. For datajson it makes sense to keep the newest since most likely the oldest is the package that has no harvest object associated, so we use `newest` as the default for this new option.